### PR TITLE
Small cleanups

### DIFF
--- a/internal/util/bytes.go
+++ b/internal/util/bytes.go
@@ -1,0 +1,9 @@
+package util
+
+// To bytes converts a string to a slice of bytes, terminated by '\r'.
+func ToBytes(s string) []byte {
+	buf := make([]byte, len(s)+1)
+	copy(buf, s)
+	buf[len(s)] = '\r'
+	return buf
+}

--- a/internal/util/bytes_test.go
+++ b/internal/util/bytes_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestToBytes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []byte
+	}{{
+		want: []byte{'\r'},
+	}, {
+		in:   "foo",
+		want: []byte{'f', 'o', 'o', '\r'},
+	}, {
+		in:   "test\r",
+		want: []byte{'t', 'e', 's', 't', '\r', '\r'},
+	}, {
+		in:   "sp a ce",
+		want: []byte{'s', 'p', ' ', 'a', ' ', 'c', 'e', '\r'},
+	}}
+
+	for _, tc := range cases {
+		got := ToBytes(tc.in)
+
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("ToBytes(%q) got %q want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/avr/avr1912.go
+++ b/pkg/avr/avr1912.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/seanrees/denon-api/internal/util"
 )
 
 var (
@@ -27,11 +29,6 @@ type DenonAvr1912 struct {
 }
 
 type avr1912Connection struct {
-	InputSource  string
-	MasterVolume string
-	Power        string
-	SurroundMode string
-
 	// Address (host:port) to connect to a Denon AVR1912.
 	addr string
 
@@ -97,10 +94,7 @@ func (avr *avr1912Connection) innerConnect() bool {
 		select {
 		case c := <-avr.commands:
 			log.Printf("writing %s", c.command)
-			buf := make([]byte, len(c.command)+1)
-			copy(buf, c.command)
-			buf[len(c.command)] = '\r'
-
+			buf := util.ToBytes(c.command)
 			out, err := conn.Write(buf)
 			if err != nil || out < len(buf) {
 				log.Printf("error: could not write %d bytes to %s: %v", len(buf), avr.addr, err)

--- a/test/fakes/fake_avr1912.go
+++ b/test/fakes/fake_avr1912.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"strings"
 	"time"
+
+	"github.com/seanrees/denon-api/internal/util"
 )
 
 type FakeAvr1912 struct {
@@ -49,7 +51,7 @@ func (f *FakeAvr1912) Serve() {
 				break
 			}
 
-			conn.Write(toBytes(welcome))
+			conn.Write(util.ToBytes(welcome))
 
 			go f.handle(conn)
 		}
@@ -79,7 +81,7 @@ func (f *FakeAvr1912) handle(conn net.Conn) {
 			}
 
 			if len(f.Heartbeat) > 0 {
-				conn.Write(toBytes(f.Heartbeat))
+				conn.Write(util.ToBytes(f.Heartbeat))
 			}
 		}
 
@@ -89,7 +91,7 @@ func (f *FakeAvr1912) handle(conn net.Conn) {
 
 		if resp, ok := f.CommandResponse[command]; ok {
 			for _, r := range resp {
-				buf := toBytes(r)
+				buf := util.ToBytes(r)
 				out, err := conn.Write(buf)
 				if err != nil || out < len(buf) {
 					log.Printf("error: could not write %d bytes to %s: %v", len(buf), conn.RemoteAddr(), err)
@@ -98,11 +100,4 @@ func (f *FakeAvr1912) handle(conn net.Conn) {
 			}
 		}
 	}
-}
-
-func toBytes(s string) []byte {
-	buf := make([]byte, len(s)+1)
-	copy(buf, s)
-	buf[len(s)] = '\r'
-	return buf
 }


### PR DESCRIPTION
Remove now-unused unit state from avr1912Connection. The original design would have kept this state, but it turned out to not be needed/useful.

Factor out the duplicated toBytes function into a small utility package.